### PR TITLE
Add fixed seed snapshots to training loop

### DIFF
--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -353,6 +353,12 @@ def training_loop(
             images = torch.cat([G_ema(z=z, c=c, noise_mode='const').cpu() for z, c in zip(grid_z, grid_c)]).numpy()
             save_image_grid(images, os.path.join(run_dir, f'fakes{cur_nimg//1000:06d}.png'), drange=[-1,1], grid_size=grid_size)
 
+            fixed_z = np.stack([np.random.RandomState(seed).randn(G.z_dim).astype(np.float32) for seed in range(16)])
+            fixed_z = torch.from_numpy(fixed_z).to(device).split(batch_gpu)
+            fixed_c = torch.zeros([16, G.c_dim], device=device).split(batch_gpu)
+            fixed_images = torch.cat([G_ema(z=z, c=c, noise_mode='const').cpu() for z, c in zip(fixed_z, fixed_c)]).numpy()
+            save_image_grid(fixed_images, os.path.join(run_dir, f'fixed_fakes{cur_nimg//1000:06d}.png'), drange=[-1,1], grid_size=(4,4))
+
         # Save network snapshot.
         snapshot_pkl = None
         snapshot_data = None


### PR DESCRIPTION
## Summary
- Save a deterministic 4x4 image grid at each snapshot using seeds 0-15

## Testing
- `python -m py_compile training/training_loop.py`
- `python train.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b368c7c0832f879d368d2965ab02